### PR TITLE
Add support for numerals and ner parameters.

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -397,6 +397,14 @@ impl Channel {
         if let Some(language) = recognize_language.or(self.config.language.as_deref()) {
             url.query_pairs_mut().append_pair("language", language);
         }
+        if let Some(numerals) = self.config.numerals {
+            url.query_pairs_mut()
+                .append_pair("numerals", if numerals { "true" } else { "false" });
+        }
+        if let Some(ner) = self.config.ner {
+            url.query_pairs_mut()
+                .append_pair("ner", if ner { "true" } else { "false" });
+        }
 
         info!("Building request to {}", url);
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -113,6 +113,13 @@ pub struct Config {
     pub model: Option<String>,
     pub language: Option<String>,
     pub sensitivity_level: Option<f32>,
+
+    // These should be considered instantly deprecated.
+    //
+    // What we really need is a general way to insert arbitrary query
+    // parameters, but this allows us to unblock someone right now.
+    pub numerals: Option<bool>,
+    pub ner: Option<bool>,
 }
 
 impl Config {


### PR DESCRIPTION
This is a quick fix to unblock a user, because we didn't have the
ability to add arbitrary query parameters to the websocket request.

It should probably be followed up with a more general solution, and
the configuration format _might_ change.

For now, numerals and ner can be set in the plugin config as follows:

```xml
<plugin-factory>
  <engine id="Deepgram" name="libdgmrcp" enable="true">
    <param name="brain_url" value="wss://brain.deepgram.com/v2/"/>
    <param name="brain_username" value="{{ USERNAME }}"/>
    <param name="brain_password" value="{{ PASSWORD }}"/>
    <param name="ner" value="true"/>
    <param name="numerals" value="true"/>
  </engine>
</plugin-factory>
```
