### PR TITLE
Add additional support for vendor parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,16 @@ The following options can be specified:
 
 The following [vendor-specific
 parameters](https://tools.ietf.org/html/rfc6787#section-6.2.16) are
-supported:
+supported in a `RECOGNIZE` or `SET-PARAMS` message. In cases where a
+parameter can specified both here and in the plugin config, the
+parameters here take precedence.
 
 | name | value | description |
 | ---  | ---   | ---
-| com.deepgram.model | string | Specify the ASR model to use for this request. |
+| com.deepgram.model | string | The ASR model to use. |
+| com.deepgram.ner | bool | Enable/disable named entity recognition. |
+| com.deepgram.numerals | bool | Enable/disable the numerals feature. |
+| com.deepgram.plugin | string | Configure a plugin. Multiple plugins can be given, separated by commas. |
 
 ## Building
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -120,6 +120,7 @@ pub struct Config {
     // parameters, but this allows us to unblock someone right now.
     pub numerals: Option<bool>,
     pub ner: Option<bool>,
+    pub plugin: Option<String>,
 }
 
 impl Config {

--- a/src/vendor_params.rs
+++ b/src/vendor_params.rs
@@ -84,6 +84,16 @@ impl<'de, 'a> Deserializer<'de> for &'a mut HeaderDeserializer {
         visitor.visit_string(s.to_string())
     }
 
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        let pair = unsafe { ffi::apt_pair_array_get(self.header, self.index) };
+        let s = unsafe { (*pair).value.as_str() };
+        let value = s.parse().map_err(serde::de::Error::custom)?;
+        visitor.visit_bool(value)
+    }
+
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
@@ -105,7 +115,6 @@ impl<'de, 'a> Deserializer<'de> for &'a mut HeaderDeserializer {
     }
 
     serde::forward_to_deserialize_any! {
-            bool
             i8 i16 i32 i64 i128
             u8 u16 u32 u64 u128
             f32 f64


### PR DESCRIPTION
This commit allows you to enable ner and numerals like so:

```
Vendor-Specific-Parameters: com.deepgram.ner=true;com.deepgram.numerals=true
```

It also adds support for plugins, via vendor specific params or the
plugin config:

```
Vendor-Specific-Parameters: com.deepgram.plugin=plugin1,plugin2
```

or

```
<param name="plugin" value="plugin1,plugin2"/>
```

The precise configuration of plugins is documented elsewhere.
