### PR TITLE
Use correct completion cause code for empty ASR results

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -427,7 +427,7 @@ impl Channel {
             url.query_pairs_mut()
                 .append_pair("no_delay", if no_delay { "true" } else { "false" });
         }
-        if let Some(keyword_boost) = vendor_headers.keyword_boost.or(self.config.keyword_boost) {
+        if let Some(keyword_boost) = vendor_headers.keyword_boost.or(self.config.keyword_boost.clone()) {
             url.query_pairs_mut()
                 .append_pair("keyword_boost", &keyword_boost);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,7 +155,7 @@ impl<'de, 'a> Deserializer<'de> for &'a mut AprTableDeserializer {
         struct Access<'b> {
             fields: &'static [&'static str],
             deserializer: &'b mut AprTableDeserializer,
-        };
+        }
 
         impl<'de, 'b> SeqAccess<'de> for Access<'b> {
             type Error = Error;


### PR DESCRIPTION
*What*
This commit amends the logic for attaching the `Completion-Cause` header when the transcription results do not contain words.

*Why*
The MRCP [spec](https://datatracker.ietf.org/doc/html/rfc6787#section-9.4.11) for the `Completion-Cause` header specifies that, if "no match was found" by the recognition engine, then `Cause-Code 001` should be used to clarify that "RECOGNIZE completed, but no match was found."