### PR TITLE
Some tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "async-tungstenite"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +187,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "ctor"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+dependencies = [
+ "quote 1.0.7",
+ "syn",
+]
+
+[[package]]
 name = "dgmrcp"
 version = "0.3.6"
 dependencies = [
@@ -189,6 +208,7 @@ dependencies = [
  "http",
  "itertools",
  "log",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "thiserror",
@@ -196,6 +216,12 @@ dependencies = [
  "url",
  "xml-rs",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -568,6 +594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +651,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-hack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ thiserror = "1.0"
 tokio = { version = "0.3", features = ["rt", "rt-multi-thread", "stream", "sync"] }
 url = { version = "2.1", features = ["serde"] }
 xml-rs = "0.8"
+
+[dev-dependencies]
+pretty_assertions = "0.7"
+


### PR DESCRIPTION
I recently did custom modifications of this plugin for a client. Thought you might benefit from some tests I've created in the process.

The following tests are added:
- `build_url` - which refactors this code into a function to test it
- `build_response`

I also have a test for `vendor_params::from_header_array` but that changes the `Dockerfile` and `build.rs` quite a bit to remove the `MRCP_INCLUDE_PATH` env variable which `cargo test` does not detect. Will you be ok with changing these two files?

Technically a test step can also be added to github actions...